### PR TITLE
Update attstore chart to v1.3.0

### DIFF
--- a/charts/attstore/.helmignore
+++ b/charts/attstore/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/
+*.log

--- a/charts/attstore/Chart.yaml
+++ b/charts/attstore/Chart.yaml
@@ -1,0 +1,32 @@
+apiVersion: v2
+name: attstore
+description: Attestation Store - A secure storage and verification system for software attestations and evidence
+type: application
+
+# Chart version - increment this when making changes to the chart
+version: 1.3.0
+
+# Application version - should match the attstore image version
+appVersion: "1.3.0"
+
+keywords:
+  - attestation
+  - sbom
+  - security
+  - supply-chain
+  - evidence
+  - scribe-security
+
+home: https://github.com/scribe-security/attstore
+sources:
+  - https://github.com/scribe-security/attstore
+
+maintainers:
+  - name: Scribe Security
+    email: support@scribesecurity.com
+
+# Optional dependencies (can be enabled/disabled via values)
+# dependencies: []
+
+# Minimum Kubernetes version
+kubeVersion: ">=1.19.0-0"

--- a/charts/attstore/examples/aws-mode.yaml
+++ b/charts/attstore/examples/aws-mode.yaml
@@ -1,0 +1,103 @@
+# Example: AWS Deployment Mode
+# Cloud-native deployment using AWS managed services (RDS, S3)
+
+replicaCount: 2
+
+# IMPORTANT: Configure IRSA for S3 access
+serviceAccount:
+  create: true
+  annotations:
+    eks.amazonaws.com/role-arn: "arn:aws:iam::123456789012:role/attstore-s3-access"  # REQUIRED: Your IAM role ARN
+
+# IMPORTANT: Set these secrets (use AWS Secrets Manager recommended)
+config:
+  sessionSecret: ""  # REQUIRED
+  jwtSecretKey: ""   # REQUIRED
+  admin:
+    password: ""  # REQUIRED
+    email: "admin@company.com"
+
+# AWS ALB Ingress
+ingress:
+  enabled: true
+  className: "alb"
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+    alb.ingress.kubernetes.io/ssl-redirect: '443'
+    alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:us-east-1:123456789012:certificate/xxxxx"  # REQUIRED
+    alb.ingress.kubernetes.io/healthcheck-path: /healthz
+  hosts:
+    - host: attstore.company.com
+      paths:
+        - path: /
+          pathType: Prefix
+
+# Production resources
+resources:
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+  requests:
+    cpu: 250m
+    memory: 512Mi
+
+# Enable autoscaling
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+
+# Multi-AZ pod distribution
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 100
+      podAffinityTerm:
+        labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/name
+            operator: In
+            values:
+            - attstore
+        topologyKey: topology.kubernetes.io/zone
+
+# AWS S3 storage
+storage:
+  type: CLOUD_STORAGE
+  persistence:
+    enabled: false
+  cloudStorage:
+    provider: AWS
+    aws:
+      bucket: "my-attstore-bucket"  # REQUIRED: Your S3 bucket
+      region: "us-east-1"  # REQUIRED: Your AWS region
+      # No credentials needed when using IRSA
+
+# External RDS PostgreSQL
+database:
+  type: postgresql
+  postgresql:
+    enabled: false  # Using external RDS
+  externalDatabase:
+    enabled: true
+    host: "attstore-db.xxxxx.us-east-1.rds.amazonaws.com"  # REQUIRED: Your RDS endpoint
+    port: 5432
+    database: "attstoredb"
+    username: "attstoreuser"
+    password: ""  # REQUIRED: Set via --set or external-secrets
+
+# Disable MinIO (using S3)
+minio:
+  enabled: false
+
+# Disable PgBouncer (can use RDS Proxy instead)
+pgbouncer:
+  enabled: false
+
+# Enable pod disruption budget
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1

--- a/charts/attstore/examples/poc-mode.yaml
+++ b/charts/attstore/examples/poc-mode.yaml
@@ -1,0 +1,23 @@
+# Example: Proof-of-Concept Mode
+# Quick start configuration for testing and development
+
+# Use default PoC values - just customize access method
+
+service:
+  type: NodePort
+  nodePort: 30503  # Access on any cluster node at port 30503
+
+# Optional: Add resource limits for shared dev clusters
+resources:
+  limits:
+    cpu: 200m
+    memory: 256Mi
+  requests:
+    cpu: 50m
+    memory: 128Mi
+
+# All other settings use defaults from values.yaml:
+# - SQLite database
+# - Local file storage (10Gi PVC)
+# - 1 replica
+# - No PostgreSQL or MinIO

--- a/charts/attstore/examples/production-mode.yaml
+++ b/charts/attstore/examples/production-mode.yaml
@@ -1,0 +1,89 @@
+# Example: Production Mode (Stand-Alone Full System)
+# Complete self-contained production deployment with PostgreSQL and MinIO
+
+replicaCount: 2
+
+# IMPORTANT: Set these secrets securely
+config:
+  sessionSecret: ""  # REQUIRED: Set via --set or use external-secrets
+  jwtSecretKey: ""   # REQUIRED: Set via --set or use external-secrets
+  admin:
+    password: ""  # REQUIRED: Set via --set
+    email: "admin@company.com"
+
+# Enable Ingress with your domain
+ingress:
+  enabled: true
+  className: "nginx"
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+  hosts:
+    - host: attstore.company.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: attstore-tls
+      hosts:
+        - attstore.company.com
+
+# Production resources
+resources:
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+  requests:
+    cpu: 250m
+    memory: 512Mi
+
+# Enable MinIO for object storage
+storage:
+  type: CLOUD_STORAGE
+  cloudStorage:
+    provider: MINIO
+    minio:
+      secure: "false"  # Set to "true" if MinIO has TLS
+
+# Enable PostgreSQL
+database:
+  type: postgresql
+  postgresql:
+    enabled: true
+    password: ""  # Will be auto-generated, retrieve from secret
+    persistence:
+      enabled: true
+      storageClass: "fast-ssd"  # Use your production storage class
+      size: 20Gi
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+      requests:
+        cpu: 500m
+        memory: 512Mi
+
+# Enable MinIO
+minio:
+  enabled: true
+  rootPassword: ""  # Will be auto-generated, retrieve from secret
+  persistence:
+    enabled: true
+    storageClass: "standard"  # Use your storage class
+    size: 50Gi
+  resources:
+    limits:
+      cpu: 2000m
+      memory: 2Gi
+    requests:
+      cpu: 1000m
+      memory: 1Gi
+
+# Enable connection pooler
+pgbouncer:
+  enabled: true
+
+# Enable pod disruption budget
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1

--- a/charts/attstore/templates/NOTES.txt
+++ b/charts/attstore/templates/NOTES.txt
@@ -1,0 +1,149 @@
+🎉 Attestation Store has been deployed!
+
+Release Name: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+
+{{- if .Values.ingress.enabled }}
+
+📡 Access URL:
+{{- range .Values.ingress.hosts }}
+  {{- if .tls }}
+  https://{{ .host }}
+  {{- else }}
+  http://{{ .host }}
+  {{- end }}
+{{- end }}
+
+{{- else if eq .Values.service.type "NodePort" }}
+
+📡 Access via NodePort:
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "attstore.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo "http://$NODE_IP:$NODE_PORT"
+
+{{- else if eq .Values.service.type "LoadBalancer" }}
+
+📡 Access via LoadBalancer:
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+  
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "attstore.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo "http://$SERVICE_IP:{{ .Values.service.port }}"
+
+{{- else }}
+
+📡 Access via Port-Forward:
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "attstore.fullname" . }} 5003:{{ .Values.service.port }}
+  
+  Then visit: http://localhost:5003
+
+{{- end }}
+
+🔐 Default Admin Credentials:
+  Username: {{ .Values.config.admin.username }}
+  {{- if eq .Values.config.admin.password "admin#admin" }}
+  Password: admin#admin  ⚠️  CHANGE THIS IMMEDIATELY IN PRODUCTION!
+  {{- else }}
+  Password: (retrieve from secret)
+    kubectl get secret --namespace {{ .Release.Namespace }} {{ include "attstore.fullname" . }} -o jsonpath="{.data.DEFAULT_ADMIN_PASSWORD}" | base64 --decode
+  {{- end }}
+
+{{- if .Values.database.postgresql.enabled }}
+
+🗄️  PostgreSQL Database:
+  Host: {{ include "attstore.postgresql.fullname" . }}
+  Port: {{ .Values.database.postgresql.port }}
+  Database: {{ .Values.database.postgresql.database }}
+  Username: {{ .Values.database.postgresql.username }}
+  
+  Retrieve password:
+    kubectl get secret --namespace {{ .Release.Namespace }} {{ include "attstore.postgresql.fullname" . }} -o jsonpath="{.data.POSTGRES_PASSWORD}" | base64 --decode
+
+{{- end }}
+
+{{- if .Values.minio.enabled }}
+
+📦 MinIO Object Storage:
+  API URL: http://{{ include "attstore.minio.fullname" . }}:{{ .Values.minio.service.port }}
+  Console URL: http://{{ include "attstore.minio.fullname" . }}:{{ .Values.minio.service.consolePort }}
+  Root User: {{ .Values.minio.rootUser }}
+  
+  Retrieve root password:
+    kubectl get secret --namespace {{ .Release.Namespace }} {{ include "attstore.minio.fullname" . }} -o jsonpath="{.data.MINIO_ROOT_PASSWORD}" | base64 --decode
+  
+  Access MinIO Console (port-forward):
+    kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "attstore.minio.fullname" . }} 9001:{{ .Values.minio.service.consolePort }}
+    Then visit: http://localhost:9001
+
+{{- end }}
+
+{{- if .Values.database.externalDatabase.enabled }}
+
+🗄️  External Database Configuration:
+  {{- if .Values.database.externalDatabase.host }}
+  Host: {{ .Values.database.externalDatabase.host }}
+  {{- else }}
+  ⚠️  External database host not configured! Set database.externalDatabase.host
+  {{- end }}
+  Database: {{ .Values.database.externalDatabase.database }}
+  Username: {{ .Values.database.externalDatabase.username }}
+
+{{- end }}
+
+{{- if eq .Values.storage.cloudStorage.provider "AWS" }}
+
+☁️  AWS S3 Storage:
+  {{- if .Values.storage.cloudStorage.aws.bucket }}
+  Bucket: {{ .Values.storage.cloudStorage.aws.bucket }}
+  {{- else }}
+  ⚠️  S3 bucket not configured! Set storage.cloudStorage.aws.bucket
+  {{- end }}
+  Region: {{ .Values.storage.cloudStorage.aws.region }}
+  {{- if .Values.serviceAccount.annotations }}
+  {{- if index .Values.serviceAccount.annotations "eks.amazonaws.com/role-arn" }}
+  IAM Role (IRSA): {{ index .Values.serviceAccount.annotations "eks.amazonaws.com/role-arn" }}
+  {{- else }}
+  ⚠️  IRSA not configured. Add eks.amazonaws.com/role-arn annotation to serviceAccount
+  {{- end }}
+  {{- end }}
+
+{{- end }}
+
+📊 Monitoring:
+  Check deployment status:
+    kubectl --namespace {{ .Release.Namespace }} get deployment {{ include "attstore.fullname" . }}
+  
+  View logs:
+    kubectl --namespace {{ .Release.Namespace }} logs -f deployment/{{ include "attstore.fullname" . }}
+  
+  Health check:
+    kubectl --namespace {{ .Release.Namespace }} exec -it deployment/{{ include "attstore.fullname" . }} -- curl http://localhost:{{ .Values.config.port }}/healthz
+
+📚 Documentation:
+  Chart README: https://github.com/scribe-security/attstore/tree/main/helm/attstore
+  Application Docs: Built into the application at /docs endpoint
+
+⚙️  Configuration Notes:
+{{- if not .Values.config.sessionSecret }}
+  • Session secret was auto-generated. For production, set config.sessionSecret
+{{- end }}
+{{- if not .Values.config.jwtSecretKey }}
+  • JWT secret was auto-generated. For production, set config.jwtSecretKey
+{{- end }}
+{{- if and .Values.database.postgresql.enabled (not .Values.database.postgresql.password) }}
+  • PostgreSQL password was auto-generated
+{{- end }}
+{{- if and .Values.minio.enabled (not .Values.minio.rootPassword) }}
+  • MinIO password was auto-generated
+{{- end }}
+
+{{- if eq .Values.config.admin.password "admin#admin" }}
+
+⚠️  SECURITY WARNING:
+  Default admin password is in use!
+  Please change it immediately after first login.
+
+{{- end }}
+
+For more information, run:
+  helm status {{ .Release.Name }} --namespace {{ .Release.Namespace }}
+  helm get values {{ .Release.Name }} --namespace {{ .Release.Namespace }}

--- a/charts/attstore/templates/_helpers.tpl
+++ b/charts/attstore/templates/_helpers.tpl
@@ -1,0 +1,240 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "attstore.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "attstore.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "attstore.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "attstore.labels" -}}
+helm.sh/chart: {{ include "attstore.chart" . }}
+{{ include "attstore.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "attstore.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "attstore.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "attstore.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "attstore.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+PostgreSQL fullname
+*/}}
+{{- define "attstore.postgresql.fullname" -}}
+{{- printf "%s-postgresql" (include "attstore.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+PostgreSQL labels
+*/}}
+{{- define "attstore.postgresql.labels" -}}
+helm.sh/chart: {{ include "attstore.chart" . }}
+{{ include "attstore.postgresql.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: database
+{{- end }}
+
+{{/*
+PostgreSQL selector labels
+*/}}
+{{- define "attstore.postgresql.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "attstore.name" . }}-postgresql
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+MinIO fullname
+*/}}
+{{- define "attstore.minio.fullname" -}}
+{{- printf "%s-minio" (include "attstore.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+MinIO labels
+*/}}
+{{- define "attstore.minio.labels" -}}
+helm.sh/chart: {{ include "attstore.chart" . }}
+{{ include "attstore.minio.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: object-storage
+{{- end }}
+
+{{/*
+MinIO selector labels
+*/}}
+{{- define "attstore.minio.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "attstore.name" . }}-minio
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+PgBouncer fullname
+*/}}
+{{- define "attstore.pgbouncer.fullname" -}}
+{{- printf "%s-pgbouncer" (include "attstore.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+PgBouncer labels
+*/}}
+{{- define "attstore.pgbouncer.labels" -}}
+helm.sh/chart: {{ include "attstore.chart" . }}
+{{ include "attstore.pgbouncer.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: connection-pooler
+{{- end }}
+
+{{/*
+PgBouncer selector labels
+*/}}
+{{- define "attstore.pgbouncer.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "attstore.name" . }}-pgbouncer
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Generate session secret
+*/}}
+{{- define "attstore.sessionSecret" -}}
+{{- if .Values.config.sessionSecret }}
+{{- .Values.config.sessionSecret }}
+{{- else }}
+{{- randAlphaNum 32 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Generate JWT secret
+*/}}
+{{- define "attstore.jwtSecret" -}}
+{{- if .Values.config.jwtSecretKey }}
+{{- .Values.config.jwtSecretKey }}
+{{- else }}
+{{- randAlphaNum 32 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Generate PostgreSQL password
+*/}}
+{{- define "attstore.postgresql.password" -}}
+{{- if .Values.database.postgresql.password }}
+{{- .Values.database.postgresql.password }}
+{{- else }}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace (include "attstore.postgresql.fullname" .)) }}
+{{- if $secret }}
+{{- index $secret.data "POSTGRES_PASSWORD" | b64dec }}
+{{- else }}
+{{- randAlphaNum 16 }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Generate MinIO root password
+*/}}
+{{- define "attstore.minio.password" -}}
+{{- if .Values.minio.rootPassword }}
+{{- .Values.minio.rootPassword }}
+{{- else }}
+{{- randAlphaNum 16 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Database URL
+*/}}
+{{- define "attstore.databaseUrl" -}}
+{{- if eq .Values.database.type "sqlite" }}
+{{- printf "sqlite:///%s" .Values.database.sqlite.path }}
+{{- else if .Values.database.externalDatabase.enabled }}
+{{- if .Values.database.externalDatabase.url }}
+{{- .Values.database.externalDatabase.url }}
+{{- else }}
+{{- printf "postgresql://%s:%s@%s:%d/%s" .Values.database.externalDatabase.username .Values.database.externalDatabase.password .Values.database.externalDatabase.host (.Values.database.externalDatabase.port | int) .Values.database.externalDatabase.database }}
+{{- end }}
+{{- else if .Values.database.postgresql.enabled }}
+{{- if .Values.pgbouncer.enabled }}
+{{- printf "postgresql://%s:%s@%s:6432/%s" .Values.database.postgresql.username (include "attstore.postgresql.password" .) (include "attstore.pgbouncer.fullname" .) .Values.database.postgresql.database }}
+{{- else }}
+{{- printf "postgresql://%s:%s@%s:%d/%s" .Values.database.postgresql.username (include "attstore.postgresql.password" .) (include "attstore.postgresql.fullname" .) (.Values.database.postgresql.port | int) .Values.database.postgresql.database }}
+{{- end }}
+{{- else }}
+{{- printf "sqlite:///attestation_store.db" }}
+{{- end }}
+{{- end }}
+
+{{/*
+File storage base URL
+*/}}
+{{- define "attstore.fileStorageBaseUrl" -}}
+{{- if .Values.storage.fileMount.baseUrl }}
+{{- .Values.storage.fileMount.baseUrl }}
+{{- else }}
+{{- printf "http://%s:%d/download" (include "attstore.fullname" .) (.Values.service.port | int) }}
+{{- end }}
+{{- end }}
+
+{{/*
+MinIO endpoint
+*/}}
+{{- define "attstore.minioEndpoint" -}}
+{{- if .Values.storage.cloudStorage.minio.endpoint }}
+{{- .Values.storage.cloudStorage.minio.endpoint }}
+{{- else if .Values.minio.enabled }}
+{{- printf "http://%s:%d" (include "attstore.minio.fullname" .) (.Values.minio.service.port | int) }}
+{{- else }}
+{{- "" }}
+{{- end }}
+{{- end }}

--- a/charts/attstore/templates/configmap.yaml
+++ b/charts/attstore/templates/configmap.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "attstore.fullname" . }}
+  labels:
+    {{- include "attstore.labels" . | nindent 4 }}
+data:
+  PORT: {{ .Values.config.port | quote }}
+  STORAGE_TYPE: {{ .Values.storage.type | quote }}
+  {{- if eq .Values.storage.type "FILE_MOUNT" }}
+  FILE_STORAGE_PATH: {{ .Values.storage.fileMount.path | quote }}
+  FILE_STORAGE_BASE_URL: {{ include "attstore.fileStorageBaseUrl" . | quote }}
+  {{- else if eq .Values.storage.type "CLOUD_STORAGE" }}
+  CLOUD_STORAGE_PROVIDER: {{ .Values.storage.cloudStorage.provider | quote }}
+  {{- if eq .Values.storage.cloudStorage.provider "AWS" }}
+  AWS_DEFAULT_REGION: {{ .Values.storage.cloudStorage.aws.region | quote }}
+  {{- if .Values.storage.cloudStorage.aws.bucket }}
+  S3_BUCKET: {{ .Values.storage.cloudStorage.aws.bucket | quote }}
+  {{- end }}
+  {{- else if eq .Values.storage.cloudStorage.provider "MINIO" }}
+  MINIO_ENDPOINT: {{ include "attstore.minioEndpoint" . | quote }}
+  {{- if .Values.storage.cloudStorage.minio.bucket }}
+  MINIO_BUCKET: {{ .Values.storage.cloudStorage.minio.bucket | quote }}
+  {{- else if .Values.minio.enabled }}
+  MINIO_BUCKET: {{ .Values.minio.bucket | quote }}
+  {{- end }}
+  MINIO_SECURE: {{ .Values.storage.cloudStorage.minio.secure | quote }}
+  {{- end }}
+  {{- end }}
+  PRESIGNED_URL_EXPIRATION: {{ .Values.config.presignedUrlExpiration | quote }}
+  SYSLOG_FACILITY: {{ .Values.config.syslog.facility | quote }}
+  SYSLOG_HOSTNAME: {{ .Values.config.syslog.hostname | quote }}
+  SYSLOG_APP_NAME: {{ .Values.config.syslog.appName | quote }}
+  DEFAULT_ADMIN_USERNAME: {{ .Values.config.admin.username | quote }}
+  DEFAULT_ADMIN_EMAIL: {{ .Values.config.admin.email | quote }}
+  PYTHONUNBUFFERED: "1"

--- a/charts/attstore/templates/deployment.yaml
+++ b/charts/attstore/templates/deployment.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "attstore.fullname" . }}
+  labels:
+    {{- include "attstore.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "attstore.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "attstore.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "attstore.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.database.postgresql.enabled }}
+      initContainers:
+      - name: wait-for-db
+        image: busybox:1.36
+        command: ['sh', '-c']
+        args:
+        - |
+          until nc -z {{ include "attstore.postgresql.fullname" . }} 5432; do
+            echo "Waiting for PostgreSQL to be ready..."
+            sleep 2
+          done
+          echo "PostgreSQL is ready!"
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 12 }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.config.port }}
+          protocol: TCP
+        envFrom:
+        - configMapRef:
+            name: {{ include "attstore.fullname" . }}
+        - secretRef:
+            name: {{ include "attstore.fullname" . }}
+        livenessProbe:
+          {{- toYaml .Values.livenessProbe | nindent 12 }}
+        readinessProbe:
+          {{- toYaml .Values.readinessProbe | nindent 12 }}
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
+        volumeMounts:
+        {{- if and (eq .Values.storage.type "FILE_MOUNT") .Values.storage.persistence.enabled }}
+        - name: storage
+          mountPath: {{ .Values.storage.fileMount.path }}
+        {{- end }}
+        {{- if eq .Values.database.type "sqlite" }}
+        - name: storage
+          mountPath: /app/instance
+          subPath: instance
+        {{- end }}
+      volumes:
+      {{- if or (and (eq .Values.storage.type "FILE_MOUNT") .Values.storage.persistence.enabled) (eq .Values.database.type "sqlite") }}
+      - name: storage
+        {{- if .Values.storage.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.storage.persistence.existingClaim | default (include "attstore.fullname" .) }}
+        {{- else }}
+        emptyDir: {}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/attstore/templates/ingress.yaml
+++ b/charts/attstore/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "attstore.fullname" . }}
+  labels:
+    {{- include "attstore.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "attstore.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/attstore/templates/minio/deployment.yaml
+++ b/charts/attstore/templates/minio/deployment.yaml
@@ -1,0 +1,72 @@
+{{- if .Values.minio.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "attstore.minio.fullname" . }}
+  labels:
+    {{- include "attstore.minio.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "attstore.minio.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "attstore.minio.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+      - name: minio
+        image: "{{ .Values.minio.image.repository }}:{{ .Values.minio.image.tag }}"
+        imagePullPolicy: {{ .Values.minio.image.pullPolicy }}
+        command:
+        - /bin/sh
+        - -c
+        args:
+        - |
+          minio server /data --console-address ":9001" &
+          MINIO_PID=$!
+          sleep 5
+          mc alias set myminio http://localhost:9000 $MINIO_ROOT_USER $MINIO_ROOT_PASSWORD
+          mc mb myminio/{{ .Values.minio.bucket }} --ignore-existing
+          wait $MINIO_PID
+        ports:
+        - name: api
+          containerPort: 9000
+          protocol: TCP
+        - name: console
+          containerPort: 9001
+          protocol: TCP
+        envFrom:
+        - secretRef:
+            name: {{ include "attstore.minio.fullname" . }}
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /minio/health/ready
+            port: 9000
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+        resources:
+          {{- toYaml .Values.minio.resources | nindent 12 }}
+        volumeMounts:
+        - name: data
+          mountPath: /data
+      volumes:
+      - name: data
+        {{- if .Values.minio.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ include "attstore.minio.fullname" . }}
+        {{- else }}
+        emptyDir: {}
+        {{- end }}
+{{- end }}

--- a/charts/attstore/templates/minio/pvc.yaml
+++ b/charts/attstore/templates/minio/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.minio.enabled .Values.minio.persistence.enabled -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "attstore.minio.fullname" . }}
+  labels:
+    {{- include "attstore.minio.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.minio.persistence.accessMode }}
+  {{- if .Values.minio.persistence.storageClass }}
+  storageClassName: {{ .Values.minio.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.minio.persistence.size }}
+{{- end }}

--- a/charts/attstore/templates/minio/secret.yaml
+++ b/charts/attstore/templates/minio/secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.minio.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "attstore.minio.fullname" . }}
+  labels:
+    {{- include "attstore.minio.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  MINIO_ROOT_USER: {{ .Values.minio.rootUser | quote }}
+  MINIO_ROOT_PASSWORD: {{ include "attstore.minio.password" . | quote }}
+{{- end }}

--- a/charts/attstore/templates/minio/service.yaml
+++ b/charts/attstore/templates/minio/service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.minio.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "attstore.minio.fullname" . }}
+  labels:
+    {{- include "attstore.minio.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.minio.service.type }}
+  ports:
+    - port: {{ .Values.minio.service.port }}
+      targetPort: api
+      protocol: TCP
+      name: api
+    - port: {{ .Values.minio.service.consolePort }}
+      targetPort: console
+      protocol: TCP
+      name: console
+  selector:
+    {{- include "attstore.minio.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/attstore/templates/pgbouncer-deployment.yaml
+++ b/charts/attstore/templates/pgbouncer-deployment.yaml
@@ -1,0 +1,58 @@
+{{- if and .Values.database.postgresql.enabled .Values.pgbouncer.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "attstore.pgbouncer.fullname" . }}
+  labels:
+    {{- include "attstore.pgbouncer.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "attstore.pgbouncer.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "attstore.pgbouncer.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+      - name: pgbouncer
+        image: "{{ .Values.pgbouncer.image.repository }}:{{ .Values.pgbouncer.image.tag }}"
+        imagePullPolicy: {{ .Values.pgbouncer.image.pullPolicy }}
+        ports:
+        - name: pgbouncer
+          containerPort: 6432
+          protocol: TCP
+        env:
+        - name: DB_HOST
+          value: {{ include "attstore.postgresql.fullname" . }}
+        - name: DB_PORT
+          value: "5432"
+        - name: DB_USER
+          value: {{ .Values.database.postgresql.username }}
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "attstore.postgresql.fullname" . }}
+              key: POSTGRES_PASSWORD
+        - name: DB_NAME
+          value: {{ .Values.database.postgresql.database }}
+        - name: POOL_MODE
+          value: {{ .Values.pgbouncer.poolMode }}
+        - name: MAX_CLIENT_CONN
+          value: {{ .Values.pgbouncer.maxClientConn | quote }}
+        - name: DEFAULT_POOL_SIZE
+          value: {{ .Values.pgbouncer.defaultPoolSize | quote }}
+        resources:
+          {{- toYaml .Values.pgbouncer.resources | nindent 12 }}
+        livenessProbe:
+          tcpSocket:
+            port: 6432
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        readinessProbe:
+          tcpSocket:
+            port: 6432
+          initialDelaySeconds: 5
+          periodSeconds: 5
+{{- end }}

--- a/charts/attstore/templates/pgbouncer-service.yaml
+++ b/charts/attstore/templates/pgbouncer-service.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.database.postgresql.enabled .Values.pgbouncer.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "attstore.pgbouncer.fullname" . }}
+  labels:
+    {{- include "attstore.pgbouncer.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+  - port: 6432
+    targetPort: 6432
+    protocol: TCP
+    name: pgbouncer
+  selector:
+    {{- include "attstore.pgbouncer.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/attstore/templates/postgresql/secret.yaml
+++ b/charts/attstore/templates/postgresql/secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.database.postgresql.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "attstore.postgresql.fullname" . }}
+  labels:
+    {{- include "attstore.postgresql.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  POSTGRES_USER: {{ .Values.database.postgresql.username | quote }}
+  POSTGRES_PASSWORD: {{ include "attstore.postgresql.password" . | quote }}
+  POSTGRES_DB: {{ .Values.database.postgresql.database | quote }}
+{{- end }}

--- a/charts/attstore/templates/postgresql/service.yaml
+++ b/charts/attstore/templates/postgresql/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.database.postgresql.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "attstore.postgresql.fullname" . }}
+  labels:
+    {{- include "attstore.postgresql.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.database.postgresql.port }}
+      targetPort: postgresql
+      protocol: TCP
+      name: postgresql
+  selector:
+    {{- include "attstore.postgresql.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/attstore/templates/postgresql/statefulset.yaml
+++ b/charts/attstore/templates/postgresql/statefulset.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.database.postgresql.enabled -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "attstore.postgresql.fullname" . }}
+  labels:
+    {{- include "attstore.postgresql.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "attstore.postgresql.fullname" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "attstore.postgresql.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "attstore.postgresql.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+      - name: postgresql
+        image: "{{ .Values.database.postgresql.image.repository }}:{{ .Values.database.postgresql.image.tag }}"
+        imagePullPolicy: {{ .Values.database.postgresql.image.pullPolicy }}
+        ports:
+        - name: postgresql
+          containerPort: 5432
+          protocol: TCP
+        envFrom:
+        - secretRef:
+            name: {{ include "attstore.postgresql.fullname" . }}
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - exec pg_isready -U {{ .Values.database.postgresql.username | quote }} -d {{ .Values.database.postgresql.database | quote }} -h 127.0.0.1 -p 5432
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 6
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - exec pg_isready -U {{ .Values.database.postgresql.username | quote }} -d {{ .Values.database.postgresql.database | quote }} -h 127.0.0.1 -p 5432
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+        resources:
+          {{- toYaml .Values.database.postgresql.resources | nindent 12 }}
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/postgresql/data
+          subPath: postgres
+  {{- if .Values.database.postgresql.persistence.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+      labels:
+        {{- include "attstore.postgresql.labels" . | nindent 8 }}
+    spec:
+      accessModes:
+        - {{ .Values.database.postgresql.persistence.accessMode }}
+      {{- if .Values.database.postgresql.persistence.storageClass }}
+      storageClassName: {{ .Values.database.postgresql.persistence.storageClass | quote }}
+      {{- end }}
+      resources:
+        requests:
+          storage: {{ .Values.database.postgresql.persistence.size }}
+  {{- else }}
+      volumes:
+      - name: data
+        emptyDir: {}
+  {{- end }}
+{{- end }}

--- a/charts/attstore/templates/pvc.yaml
+++ b/charts/attstore/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.storage.persistence.enabled (not .Values.storage.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "attstore.fullname" . }}
+  labels:
+    {{- include "attstore.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.storage.persistence.accessMode }}
+  {{- if .Values.storage.persistence.storageClass }}
+  storageClassName: {{ .Values.storage.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.storage.persistence.size }}
+{{- end }}

--- a/charts/attstore/templates/secret.yaml
+++ b/charts/attstore/templates/secret.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "attstore.fullname" . }}
+  labels:
+    {{- include "attstore.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  SESSION_SECRET: {{ include "attstore.sessionSecret" . | quote }}
+  JWT_SECRET_KEY: {{ include "attstore.jwtSecret" . | quote }}
+  DEFAULT_ADMIN_PASSWORD: {{ .Values.config.admin.password | quote }}
+  DATABASE_URL: {{ include "attstore.databaseUrl" . | quote }}
+  {{- if eq .Values.storage.type "CLOUD_STORAGE" }}
+  {{- if eq .Values.storage.cloudStorage.provider "AWS" }}
+  {{- if .Values.storage.cloudStorage.aws.accessKeyId }}
+  AWS_ACCESS_KEY_ID: {{ .Values.storage.cloudStorage.aws.accessKeyId | quote }}
+  {{- end }}
+  {{- if .Values.storage.cloudStorage.aws.secretAccessKey }}
+  AWS_SECRET_ACCESS_KEY: {{ .Values.storage.cloudStorage.aws.secretAccessKey | quote }}
+  {{- end }}
+  {{- if .Values.storage.cloudStorage.aws.sessionToken }}
+  AWS_SESSION_TOKEN: {{ .Values.storage.cloudStorage.aws.sessionToken | quote }}
+  {{- end }}
+  {{- else if eq .Values.storage.cloudStorage.provider "MINIO" }}
+  {{- if .Values.storage.cloudStorage.minio.accessKey }}
+  MINIO_ACCESS_KEY: {{ .Values.storage.cloudStorage.minio.accessKey | quote }}
+  {{- end }}
+  {{- if .Values.storage.cloudStorage.minio.secretKey }}
+  MINIO_SECRET_KEY: {{ .Values.storage.cloudStorage.minio.secretKey | quote }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.database.externalDatabase.enabled }}
+  {{- if .Values.database.externalDatabase.password }}
+  POSTGRES_PASSWORD: {{ .Values.database.externalDatabase.password | quote }}
+  {{- end }}
+  {{- end }}

--- a/charts/attstore/templates/service.yaml
+++ b/charts/attstore/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "attstore.fullname" . }}
+  labels:
+    {{- include "attstore.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http
+      {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
+  selector:
+    {{- include "attstore.selectorLabels" . | nindent 4 }}

--- a/charts/attstore/templates/serviceaccount.yaml
+++ b/charts/attstore/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "attstore.serviceAccountName" . }}
+  labels:
+    {{- include "attstore.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/attstore/templates/tests/test-connection.yaml
+++ b/charts/attstore/templates/tests/test-connection.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "attstore.fullname" . }}-test-connection"
+  labels:
+    {{- include "attstore.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "attstore.fullname" . }}:{{ .Values.service.port }}/healthz']
+  restartPolicy: Never

--- a/charts/attstore/values-aws.yaml
+++ b/charts/attstore/values-aws.yaml
@@ -1,0 +1,244 @@
+# AWS values for attstore - AWS Deployment Mode
+# This configuration uses AWS managed services (S3 for storage, RDS for database)
+# Suitable for production AWS/EKS deployments
+
+replicaCount: 2
+
+image:
+  repository: ghcr.io/scribe-security/attstore
+  pullPolicy: IfNotPresent
+  tag: "1.3.0"
+
+imagePullSecrets: []
+
+# Service account with IRSA annotations for AWS access
+serviceAccount:
+  create: true
+  annotations:
+    # IMPORTANT: Set this to your IAM role ARN for IRSA
+    # eks.amazonaws.com/role-arn: "arn:aws:iam::ACCOUNT_ID:role/attstore-s3-access"
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  fsGroup: 1000
+
+securityContext:
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: false
+  runAsNonRoot: true
+  runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 5003
+  targetPort: 5003
+
+# Enable ALB Ingress for AWS
+ingress:
+  enabled: true
+  className: "alb"
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+    alb.ingress.kubernetes.io/ssl-redirect: '443'
+    # Certificate ARN for HTTPS
+    # alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:REGION:ACCOUNT_ID:certificate/CERT_ID"
+    alb.ingress.kubernetes.io/healthcheck-path: /healthz
+    alb.ingress.kubernetes.io/healthcheck-interval-seconds: '15'
+    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: '5'
+    alb.ingress.kubernetes.io/healthy-threshold-count: '2'
+    alb.ingress.kubernetes.io/unhealthy-threshold-count: '2'
+  hosts:
+    - host: attstore.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []  # TLS handled by ALB
+
+resources:
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+  requests:
+    cpu: 250m
+    memory: 512Mi
+
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 5003
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: 5003
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+# Enable autoscaling for AWS
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+tolerations: []
+
+# Anti-affinity to spread pods across AZs
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - weight: 100
+      podAffinityTerm:
+        labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/name
+            operator: In
+            values:
+            - attstore
+        topologyKey: topology.kubernetes.io/zone
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+config:
+  port: 5003
+  # IMPORTANT: Set strong secrets via AWS Secrets Manager or external-secrets
+  sessionSecret: ""  # Retrieve from AWS Secrets Manager
+  jwtSecretKey: ""   # Retrieve from AWS Secrets Manager
+  
+  admin:
+    username: "admin"
+    password: ""  # Retrieve from AWS Secrets Manager
+    email: "admin@example.com"
+  
+  syslog:
+    facility: "16"
+    hostname: "attestation-store"
+    appName: "attestation-store"
+  
+  presignedUrlExpiration: "3600"
+
+# Use AWS S3 for object storage
+storage:
+  type: CLOUD_STORAGE
+  
+  fileMount:
+    path: /app/storage
+    baseUrl: ""
+  
+  persistence:
+    enabled: false  # Not needed with S3
+  
+  cloudStorage:
+    provider: AWS
+    
+    aws:
+      # When using IRSA, credentials are not needed
+      # Otherwise, provide via secrets
+      accessKeyId: ""
+      secretAccessKey: ""
+      sessionToken: ""
+      region: "us-east-1"  # Set to your AWS region
+      bucket: ""  # REQUIRED: Set your S3 bucket name
+    
+    minio:
+      endpoint: ""
+      accessKey: ""
+      secretKey: ""
+      bucket: ""
+      secure: "true"
+
+# Use external RDS PostgreSQL
+database:
+  type: postgresql
+  
+  sqlite:
+    path: /app/instance/attestation_store.db
+  
+  # Disable bundled PostgreSQL
+  postgresql:
+    enabled: false
+    
+    host: ""
+    port: 5432
+    database: attstoredb
+    username: attstoreuser
+    password: ""
+    
+    image:
+      repository: postgres
+      tag: "1.3.0"
+      pullPolicy: IfNotPresent
+    
+    persistence:
+      enabled: false
+    
+    resources: {}
+  
+  # Enable external RDS database
+  externalDatabase:
+    enabled: true
+    # Provide full connection string OR individual components
+    url: ""
+    # Individual components (if not using url):
+    host: ""  # REQUIRED: RDS endpoint (e.g., mydb.xxxx.us-east-1.rds.amazonaws.com)
+    port: 5432
+    database: "attstoredb"
+    username: "attstoreuser"
+    password: ""  # REQUIRED: Retrieve from AWS Secrets Manager
+    # For RDS IAM authentication (not yet implemented):
+    useIAM: false
+
+# Disable MinIO (using S3 instead)
+minio:
+  enabled: false
+  
+  image:
+    repository: minio/minio
+    tag: latest
+    pullPolicy: IfNotPresent
+  
+  rootUser: minioadmin
+  rootPassword: ""
+  
+  bucket: attstorebucket
+  
+  service:
+    type: ClusterIP
+    port: 9000
+    consolePort: 9001
+  
+  persistence:
+    enabled: false
+  
+  resources: {}
+
+# Disable PgBouncer (RDS Proxy can be used instead)
+pgbouncer:
+  enabled: false
+  
+  image:
+    repository: edoburu/pgbouncer
+    tag: latest
+    pullPolicy: IfNotPresent
+  
+  poolMode: transaction
+  maxClientConn: 600
+  defaultPoolSize: 20
+  
+  resources: {}

--- a/charts/attstore/values-production.yaml
+++ b/charts/attstore/values-production.yaml
@@ -1,0 +1,243 @@
+# Production values for attstore - Stand-Alone Full System
+# This configuration provides a complete self-contained deployment with PostgreSQL and MinIO
+# Suitable for production on-premises deployments
+
+replicaCount: 2
+
+image:
+  repository: ghcr.io/scribe-security/attstore
+  pullPolicy: IfNotPresent
+  tag: "1.3.0"
+
+imagePullSecrets: []
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  fsGroup: 1000
+
+securityContext:
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: false
+  runAsNonRoot: true
+  runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 5003
+  targetPort: 5003
+  # For cloud deployments, consider LoadBalancer:
+  # type: LoadBalancer
+  # For simple access without ingress:
+  # type: NodePort
+  # nodePort: 30503
+
+# Ingress is optional - disabled by default
+# Most users will use: kubectl port-forward, NodePort, or LoadBalancer
+# Enable only if you need domain-based routing or TLS termination
+ingress:
+  enabled: false
+  className: "nginx"
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+  hosts:
+    - host: attstore.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: attstore-tls
+      hosts:
+        - attstore.example.com
+
+resources:
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+  requests:
+    cpu: 250m
+    memory: 512Mi
+
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 5003
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: 5003
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+# Optional autoscaling
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# Enable pod disruption budget for production
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+config:
+  port: 5003
+  # Generate strong secrets for production - DO NOT use defaults
+  sessionSecret: ""  # Set via --set or sealed-secrets
+  jwtSecretKey: ""   # Set via --set or sealed-secrets
+  
+  admin:
+    username: "admin"
+    password: ""  # Set via --set or sealed-secrets - DO NOT use default
+    email: "admin@example.com"
+  
+  syslog:
+    facility: "16"
+    hostname: "attestation-store"
+    appName: "attestation-store"
+  
+  presignedUrlExpiration: "3600"
+
+# Use MinIO for object storage
+storage:
+  type: CLOUD_STORAGE
+  
+  fileMount:
+    path: /app/storage
+    baseUrl: ""
+  
+  persistence:
+    enabled: false  # Not needed when using cloud storage
+  
+  cloudStorage:
+    provider: MINIO
+    
+    aws:
+      accessKeyId: ""
+      secretAccessKey: ""
+      sessionToken: ""
+      region: "us-east-1"
+      bucket: ""
+    
+    minio:
+      endpoint: ""  # Auto-generated from service
+      accessKey: ""  # Will use MinIO root credentials
+      secretKey: ""  # Will use MinIO root credentials
+      bucket: ""     # Will use minio.bucket value
+      secure: "false"  # Set to "true" if MinIO has TLS
+
+# Use PostgreSQL for database
+database:
+  type: postgresql
+  
+  sqlite:
+    path: /app/instance/attestation_store.db
+  
+  # Enable bundled PostgreSQL
+  postgresql:
+    enabled: true
+    
+    host: ""  # Auto-generated
+    port: 5432
+    database: attstoredb
+    username: attstoreuser
+    password: ""  # Will be auto-generated - retrieve from secret
+    
+    image:
+      repository: postgres
+      tag: "1.3.0"
+      pullPolicy: IfNotPresent
+    
+    persistence:
+      enabled: true
+      # storageClass: "fast-ssd"  # Set for production
+      accessMode: ReadWriteOnce
+      size: 20Gi
+    
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+      requests:
+        cpu: 500m
+        memory: 512Mi
+  
+  externalDatabase:
+    enabled: false
+
+# Enable MinIO
+minio:
+  enabled: true
+  
+  image:
+    repository: minio/minio
+    tag: latest
+    pullPolicy: IfNotPresent
+  
+  rootUser: minioadmin
+  rootPassword: ""  # Will be auto-generated - retrieve from secret
+  
+  bucket: attstorebucket
+  
+  service:
+    type: ClusterIP
+    port: 9000
+    consolePort: 9001
+  
+  persistence:
+    enabled: true
+    # storageClass: "fast-ssd"  # Set for production
+    accessMode: ReadWriteOnce
+    size: 50Gi
+  
+  resources:
+    limits:
+      cpu: 2000m
+      memory: 2Gi
+    requests:
+      cpu: 1000m
+      memory: 1Gi
+
+# Optional PgBouncer for connection pooling
+pgbouncer:
+  # Optional connection pooler - only needed for high-traffic deployments
+  # Set to true if you have >10 replicas or >100 concurrent connections
+  enabled: false
+  
+  image:
+    repository: edoburu/pgbouncer
+    tag: latest
+    pullPolicy: IfNotPresent
+  
+  poolMode: transaction
+  maxClientConn: 600
+  defaultPoolSize: 20
+  
+  resources:
+    limits:
+      cpu: 500m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi

--- a/charts/attstore/values.yaml
+++ b/charts/attstore/values.yaml
@@ -1,0 +1,302 @@
+# Default values for attstore - Proof of Concept Mode
+# This configuration provides a minimal setup with SQLite and local file storage
+# Suitable for testing, development, and demos
+
+# Number of replicas (PoC mode: 1 replica)
+replicaCount: 1
+
+image:
+  repository: ghcr.io/scribe-security/attstore
+  pullPolicy: IfNotPresent
+  tag: "1.3.0"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# Service account configuration
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account (for AWS IRSA, add eks.amazonaws.com/role-arn)
+  annotations: {}
+  # The name of the service account to use
+  name: ""
+
+# Pod annotations
+podAnnotations: {}
+
+# Pod security context
+podSecurityContext:
+  fsGroup: 1000
+
+# Container security context
+securityContext:
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: false
+  runAsNonRoot: true
+  runAsUser: 1000
+
+# Service configuration
+service:
+  type: ClusterIP
+  port: 5003
+  targetPort: 5003
+  # For PoC mode, you can change to NodePort for easy access
+  # type: NodePort
+  # nodePort: 30503
+
+# Ingress configuration
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: attstore.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+  #  - secretName: attstore-tls
+  #    hosts:
+  #      - attstore.local
+
+# Resource limits and requests
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 256Mi
+
+# Liveness and readiness probes
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 5003
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: 5003
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+# Autoscaling (disabled by default)
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: 80
+
+# Node selector
+nodeSelector: {}
+
+# Tolerations
+tolerations: []
+
+# Affinity rules
+affinity: {}
+
+# Pod disruption budget (disabled for PoC mode)
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
+# Application configuration
+config:
+  # Port for the application
+  port: 5003
+  
+  # Session secret - will be auto-generated if not provided
+  # For production, set a strong secret value
+  sessionSecret: ""
+  
+  # JWT secret key - will be auto-generated if not provided
+  # For production, set a strong secret value
+  jwtSecretKey: ""
+  
+  # Default admin credentials
+  admin:
+    username: "admin"
+    password: "admin#admin"  # Change immediately in production
+    email: "admin@example.com"
+  
+  # Syslog configuration
+  syslog:
+    facility: "16"
+    hostname: "attestation-store"
+    appName: "attestation-store"
+  
+  # Presigned URL expiration (seconds)
+  presignedUrlExpiration: "3600"
+
+# Storage configuration
+storage:
+  # Storage type: FILE_MOUNT or CLOUD_STORAGE
+  type: FILE_MOUNT
+  
+  # File mount storage settings (for PoC mode)
+  fileMount:
+    # Path inside container
+    path: /app/storage
+    # Base URL for download links (will be auto-generated based on service if not set)
+    baseUrl: ""
+  
+  # Persistence for local storage (PoC mode)
+  persistence:
+    enabled: true
+    # storageClass: ""  # Use cluster default
+    accessMode: ReadWriteOnce
+    size: 10Gi
+    # existingClaim: ""  # Use existing PVC
+  
+  # Cloud storage settings (disabled in PoC mode)
+  cloudStorage:
+    provider: AWS  # AWS or MINIO
+    
+    # AWS S3 configuration
+    aws:
+      accessKeyId: ""
+      secretAccessKey: ""
+      sessionToken: ""
+      region: "us-east-1"
+      bucket: ""
+    
+    # MinIO configuration
+    minio:
+      endpoint: ""
+      accessKey: ""
+      secretKey: ""
+      bucket: ""
+      secure: "true"
+
+# Database configuration
+database:
+  # Database type: sqlite or postgresql
+  type: sqlite
+  
+  # SQLite configuration (default for PoC mode)
+  sqlite:
+    # Database will be stored in persistence volume
+    path: /app/instance/attestation_store.db
+  
+  # PostgreSQL configuration (disabled by default)
+  postgresql:
+    enabled: false
+    
+    # PostgreSQL connection details (when using bundled PostgreSQL)
+    host: attstore-postgresql
+    port: 5432
+    database: attstoredb
+    username: attstoreuser
+    password: ""  # Will be auto-generated if not provided
+    
+    # PostgreSQL StatefulSet configuration
+    image:
+      repository: postgres
+      tag: "1.3.0"
+      pullPolicy: IfNotPresent
+    
+    # Persistence for PostgreSQL
+    persistence:
+      enabled: true
+      # storageClass: ""
+      accessMode: ReadWriteOnce
+      size: 20Gi
+    
+    # Resources for PostgreSQL
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+  
+  # External database configuration (for AWS/external PostgreSQL)
+  externalDatabase:
+    enabled: false
+    # Full connection string or individual components
+    url: ""
+    # Or provide individual components:
+    host: ""
+    port: 5432
+    database: ""
+    username: ""
+    password: ""
+    # For AWS RDS, you might use IAM authentication
+    useIAM: false
+
+# MinIO object storage (disabled by default)
+minio:
+  enabled: false
+  
+  image:
+    repository: minio/minio
+    tag: latest
+    pullPolicy: IfNotPresent
+  
+  # MinIO credentials (will be auto-generated if not provided)
+  rootUser: minioadmin
+  rootPassword: ""
+  
+  # Bucket name
+  bucket: attstorebucket
+  
+  # Service configuration
+  service:
+    type: ClusterIP
+    port: 9000
+    consolePort: 9001
+  
+  # Persistence for MinIO
+  persistence:
+    enabled: true
+    # storageClass: ""
+    accessMode: ReadWriteOnce
+    size: 50Gi
+  
+  # Resources for MinIO
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+    requests:
+      cpu: 500m
+      memory: 512Mi
+
+# PgBouncer configuration (optional connection pooler)
+pgbouncer:
+  enabled: false
+  
+  image:
+    repository: edoburu/pgbouncer
+    tag: latest
+    pullPolicy: IfNotPresent
+  
+  # Pool configuration
+  poolMode: transaction
+  maxClientConn: 600
+  defaultPoolSize: 20
+  
+  # Resources
+  resources:
+    limits:
+      cpu: 500m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi

--- a/index.yaml
+++ b/index.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+entries: {}
+generated: "2025-11-26T09:19:15.958528291Z"


### PR DESCRIPTION
## Helm Chart Update: attstore v1.3.0

This PR updates the `attstore` Helm chart to version **1.3.0**.

### Changes
- ✅ Updated chart version to `1.3.0`
- ✅ Updated appVersion to `1.3.0`
- ✅ Updated default image tag to `1.3.0`
- ✅ Synced all chart templates and values
- ✅ Updated Helm repository index

### Source
- **Repository**: `scribe-security/attstore`
- **Commit**: `a4e4c876e6b903d728fd9f274fc4da02aa108541`
- **Image**: `ghcr.io/scribe-security/attstore:1.3.0`

### Testing
```bash
# Test the chart
helm repo add scribe https://scribe-security.github.io/helm-charts
helm repo update
helm search repo scribe/attstore

# Install
helm install attstore scribe/attstore --version 1.3.0
```

---
*Automated sync from attstore repository*