### PR TITLE
Update attstore chart to v1.3.0

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -1,3 +1,3 @@
 apiVersion: v1
 entries: {}
-generated: "2025-11-26T09:19:15.958528291Z"
+generated: "2025-11-26T09:34:27.789049164Z"


### PR DESCRIPTION
## Helm Chart Update: attstore v1.3.0

This PR updates the `attstore` Helm chart to version **1.3.0**.

### Changes
- ✅ Updated chart version to `1.3.0`
- ✅ Updated appVersion to `1.3.0`
- ✅ Updated default image tag to `1.3.0`
- ✅ Synced all chart templates and values
- ✅ Updated Helm repository index

### Source
- **Repository**: `scribe-security/attstore`
- **Commit**: `a4e4c876e6b903d728fd9f274fc4da02aa108541`
- **Image**: `ghcr.io/scribe-security/attstore:1.3.0`

### Testing
```bash
# Test the chart
helm repo add scribe https://scribe-security.github.io/helm-charts
helm repo update
helm search repo scribe/attstore

# Install
helm install attstore scribe/attstore --version 1.3.0
```

---
*Automated sync from attstore repository*