### PR TITLE
Update attstore chart to v1.4.0

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -1,3 +1,3 @@
 apiVersion: v1
 entries: {}
-generated: "2025-11-26T10:53:46.945870899Z"
+generated: "2025-11-26T11:13:29.064122925Z"


### PR DESCRIPTION
## Helm Chart Update: attstore v1.4.0

This PR updates the `attstore` Helm chart to version **1.4.0**.

### Changes
- ✅ Updated chart version to `1.4.0`
- ✅ Updated appVersion to `1.4.0`
- ✅ Updated default image tag to `1.4.0`
- ✅ Synced all chart templates and values
- ✅ Updated Helm repository index

### Source
- **Repository**: `scribe-security/attstore`
- **Commit**: `f89ded1fe92011db004f38920610346d171a80d2`
- **Image**: `ghcr.io/scribe-security/attstore:1.4.0`

### Testing
```bash
# Test the chart
helm repo add scribe https://scribe-security.github.io/helm-charts
helm repo update
helm search repo scribe/attstore

# Install
helm install attstore scribe/attstore --version 1.4.0
```

---
*Automated sync from attstore repository*