### PR TITLE
Update attstore chart to v1.5.2

### DIFF
--- a/charts/attstore/Chart.yaml
+++ b/charts/attstore/Chart.yaml
@@ -4,10 +4,10 @@ description: Attestation Store - A secure storage and verification system for so
 type: application
 
 # Chart version - increment this when making changes to the chart
-version: 1.5.0
+version: 1.5.2
 
 # Application version - should match the attstore image version
-appVersion: "1.5.0"
+appVersion: "1.5.2"
 
 keywords:
   - attestation

--- a/charts/attstore/templates/NOTES.txt
+++ b/charts/attstore/templates/NOTES.txt
@@ -135,6 +135,22 @@ Namespace: {{ .Release.Namespace }}
 {{- if and .Values.minio.enabled (not .Values.minio.rootPassword) }}
   • MinIO password was auto-generated
 {{- end }}
+{{- if and (eq .Values.storage.type "FILE_MOUNT") (not .Values.storage.fileMount.baseUrl) }}
+{{- if not .Values.ingress.enabled }}
+  
+  ⚠️  FILE_MOUNT Storage Configuration:
+  The upload/download URLs are currently set to: {{ include "attstore.fileStorageBaseUrl" . }}
+  
+  This is an internal cluster URL and will NOT work for external clients!
+  
+  To fix this, set one of the following:
+  1. Enable ingress and configure ingress.hosts (recommended)
+  2. Set storage.fileMount.baseUrl to your external URL:
+     --set storage.fileMount.baseUrl=https://your-external-domain.com
+  3. Use port-forwarding and set:
+     --set storage.fileMount.baseUrl=http://localhost:5003
+{{- end }}
+{{- end }}
 
 {{- if eq .Values.config.admin.password "admin#admin" }}
 

--- a/charts/attstore/templates/_helpers.tpl
+++ b/charts/attstore/templates/_helpers.tpl
@@ -221,8 +221,12 @@ File storage base URL
 {{- define "attstore.fileStorageBaseUrl" -}}
 {{- if .Values.storage.fileMount.baseUrl }}
 {{- .Values.storage.fileMount.baseUrl }}
+{{- else if .Values.ingress.enabled }}
+{{- $host := (index .Values.ingress.hosts 0).host }}
+{{- $scheme := ternary "https" "http" (gt (len .Values.ingress.tls) 0) }}
+{{- printf "%s://%s" $scheme $host }}
 {{- else }}
-{{- printf "http://%s:%d/download" (include "attstore.fullname" .) (.Values.service.port | int) }}
+{{- printf "http://%s:%d" (include "attstore.fullname" .) (.Values.service.port | int) }}
 {{- end }}
 {{- end }}
 

--- a/charts/attstore/values-aws.yaml
+++ b/charts/attstore/values-aws.yaml
@@ -7,7 +7,7 @@ replicaCount: 2
 image:
   repository: ghcr.io/scribe-security/attstore
   pullPolicy: IfNotPresent
-  tag: "1.5.0"
+  tag: "1.5.2"
 
 imagePullSecrets: []
 

--- a/charts/attstore/values-production.yaml
+++ b/charts/attstore/values-production.yaml
@@ -7,7 +7,7 @@ replicaCount: 2
 image:
   repository: ghcr.io/scribe-security/attstore
   pullPolicy: IfNotPresent
-  tag: "1.5.0"
+  tag: "1.5.2"
 
 imagePullSecrets: []
 

--- a/charts/attstore/values.yaml
+++ b/charts/attstore/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/scribe-security/attstore
   pullPolicy: IfNotPresent
-  tag: "1.5.0"
+  tag: "1.5.2"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -152,7 +152,17 @@ storage:
   fileMount:
     # Path inside container
     path: /app/storage
-    # Base URL for download links (will be auto-generated based on service if not set)
+    # Base URL for download links
+    # IMPORTANT: This MUST be set to an externally accessible URL when running in production
+    # or when clients are outside the Kubernetes cluster.
+    # 
+    # Options:
+    # 1. Leave empty and enable ingress - will auto-use ingress URL (recommended)
+    # 2. Set to external LoadBalancer or NodePort URL
+    # 3. Set to port-forwarded URL (e.g., http://localhost:5003) for local development
+    # 
+    # If left empty without ingress, it will default to internal cluster URL
+    # (e.g., http://attstore:5003) which will NOT work for external clients!
     baseUrl: ""
   
   # Persistence for local storage (PoC mode)

--- a/index.yaml
+++ b/index.yaml
@@ -1,3 +1,3 @@
 apiVersion: v1
 entries: {}
-generated: "2025-11-27T06:11:43.911869588Z"
+generated: "2025-12-04T07:37:14.308971468Z"


### PR DESCRIPTION
## Helm Chart Update: attstore v1.5.2

This PR updates the `attstore` Helm chart to version **1.5.2**.

### Changes
- ✅ Updated chart version to `1.5.2`
- ✅ Updated appVersion to `1.5.2`
- ✅ Updated default image tag to `1.5.2`
- ✅ Synced all chart templates and values
- ✅ Updated Helm repository index

### Source
- **Repository**: `scribe-security/attstore`
- **Commit**: `da753dd97187d536098ddfb0e2d929e681a9dc26`
- **Image**: `ghcr.io/scribe-security/attstore:1.5.2`

### Testing
```bash
# Test the chart
helm repo add scribe https://scribe-security.github.io/helm-charts
helm repo update
helm search repo scribe/attstore

# Install
helm install attstore scribe/attstore --version 1.5.2
```

---
*Automated sync from attstore repository*