### PR TITLE
Update attstore chart to v1.10.0

### DIFF
--- a/charts/attstore/Chart.yaml
+++ b/charts/attstore/Chart.yaml
@@ -4,10 +4,10 @@ description: Attestation Store - A secure storage and verification system for so
 type: application
 
 # Chart version - increment this when making changes to the chart
-version: 1.9.1
+version: 1.10.0
 
 # Application version - should match the attstore image version
-appVersion: "1.9.1"
+appVersion: "1.10.0"
 
 keywords:
   - attestation

--- a/charts/attstore/values-aws.yaml
+++ b/charts/attstore/values-aws.yaml
@@ -7,7 +7,7 @@ replicaCount: 2
 image:
   repository: ghcr.io/scribe-security/attstore
   pullPolicy: IfNotPresent
-  tag: "1.9.1"
+  tag: "1.10.0"
 
 imagePullSecrets: []
 

--- a/charts/attstore/values-production.yaml
+++ b/charts/attstore/values-production.yaml
@@ -7,7 +7,7 @@ replicaCount: 2
 image:
   repository: ghcr.io/scribe-security/attstore
   pullPolicy: IfNotPresent
-  tag: "1.9.1"
+  tag: "1.10.0"
 
 imagePullSecrets: []
 

--- a/charts/attstore/values.yaml
+++ b/charts/attstore/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/scribe-security/attstore
   pullPolicy: IfNotPresent
-  tag: "1.9.1"
+  tag: "1.10.0"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/index.yaml
+++ b/index.yaml
@@ -1,3 +1,3 @@
 apiVersion: v1
 entries: {}
-generated: "2026-01-20T15:55:54.310295157Z"
+generated: "2026-03-12T13:20:20.708380421Z"


### PR DESCRIPTION
## Helm Chart Update: attstore v1.10.0

This PR updates the `attstore` Helm chart to version **1.10.0**.

### Changes
- ✅ Updated chart version to `1.10.0`
- ✅ Updated appVersion to `1.10.0`
- ✅ Updated default image tag to `1.10.0`
- ✅ Synced all chart templates and values
- ✅ Updated Helm repository index

### Source
- **Repository**: `scribe-security/attstore`
- **Commit**: `0b3c550d9e5acb906dfd2f57b637495f498d57eb`
- **Image**: `ghcr.io/scribe-security/attstore:1.10.0`

### Testing
```bash
# Test the chart
helm repo add scribe https://scribe-security.github.io/helm-charts
helm repo update
helm search repo scribe/attstore

# Install
helm install attstore scribe/attstore --version 1.10.0
```

---
*Automated sync from attstore repository*